### PR TITLE
chore: bootstrap Node.js server and remove Go code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
-venv/ 
+venv/
 # Python cache
 __pycache__/
 *.pyc
 data/
+# Node.js dependencies
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,26 +1,43 @@
-"# kanuka" 
+# Kanuka
 
+## Setup on AWS
 
-#To install a bot in aws
-# Install Git
+### Install Git
+```bash
 sudo yum install git -y
+```
 
-# Verify installation
+### Verify installation
+```bash
 git --version
+```
 
-# Now you can clone the repository
+### Clone the repository
+```bash
 git clone https://github.com/Pingeat/TFC--Internal-bot.git
+```
 
-
-# First, install Python 3 and pip
+### Install Python 3 and pip
+```bash
 sudo yum install python3 python3-pip -y
-
-# Verify the installation
 python3 --version
 pip3 --version
+```
 
-# Now install your requirements using pip3
+### Install dependencies
+```bash
 pip3 install -r requirements.txt
+```
 
-# Install Redis
+### Install Redis
+```bash
 sudo dnf install redis6
+```
+
+## Node.js Rewrite (Work in Progress)
+A minimal Node.js server has been added and will gradually replace the Python backend.
+
+### Run
+```bash
+node server.js
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "kanuka",
+  "version": "1.0.0",
+  "description": "Kanuka bot Node server",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,26 @@
+const http = require('http');
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'GET' && req.url === '/health') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ status: 'ok' }));
+  } else if (req.method === 'POST' && req.url === '/webhook') {
+    let body = '';
+    req.on('data', chunk => {
+      body += chunk;
+    });
+    req.on('end', () => {
+      // TODO: handle webhook logic
+      res.writeHead(200);
+      res.end();
+    });
+  } else {
+    res.writeHead(404);
+    res.end();
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Server listening on ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- remove previously added Go scaffold
- add minimal Node.js HTTP server skeleton with health and webhook stubs
- document Node server setup and ignore node_modules

## Testing
- `node server.js &` (start server)
- `curl -s http://localhost:3000/health`


------
https://chatgpt.com/codex/tasks/task_e_68a055b91edc83278f1c9ccf0e698d11