### PR TITLE
feat: add node service skeleton with redis and webhooks

### DIFF
--- a/config/redis.js
+++ b/config/redis.js
@@ -1,0 +1,5 @@
+require('dotenv').config();
+
+const REDIS_URL = process.env.REDIS_URL || 'redis://localhost:6379/0';
+
+module.exports = { REDIS_URL };

--- a/config/settings.js
+++ b/config/settings.js
@@ -1,0 +1,29 @@
+const BRANCH_COORDINATES = {
+  Kondapur: [17.4354, 78.3775],
+  Madhapur: [17.4409, 78.3490],
+  Manikonda: [17.4578, 78.3701],
+  Nizampet: [17.5152, 78.3385],
+  Nanakramguda: [17.4632, 78.3813],
+  'West Maredpally': [17.4558529177458, 78.50727064061495]
+};
+
+const DELIVERY_RADIUS_KM = 6.0;
+
+const ORDER_STATUS = {
+  PENDING: 'Pending',
+  PAID: 'Paid',
+  READY: 'Ready',
+  ON_THE_WAY: 'On The Way',
+  DELIVERED: 'Delivered',
+  CANCELLED: 'Cancelled'
+};
+
+const PRODUCT_CATALOG = {
+  '6xpxtkaoau': { name: 'Palm Jaggery - Powdered(700gms)', price: 760 },
+  'kyygkhdlxf': { name: 'Palm Jaggery - cubes(1 KG)', price: 1100 },
+  '1ado92c3xm': { name: 'Palm Jaggery - Powdered(1 KG)', price: 1100 },
+  '36dlxrjdjq': { name: 'Palm Jaggery - Powdered(500gms)', price: 550 },
+  hkaqqb8sec: { name: 'Palm Jaggery - cubes(500gms)', price: 550 }
+};
+
+module.exports = { BRANCH_COORDINATES, DELIVERY_RADIUS_KM, ORDER_STATUS, PRODUCT_CATALOG };

--- a/handlers/messageHandler.js
+++ b/handlers/messageHandler.js
@@ -1,0 +1,48 @@
+const redisState = require('../stateHandlers/redisState');
+const { sendTextMessage, sendCatalog, sendOrderConfirmation } = require('../services/whatsappService');
+const { placeOrder, isWithinDeliveryRadius } = require('../services/orderService');
+const { getLogger } = require('../utils/logger');
+const logger = getLogger('message_handler');
+
+async function handleIncomingMessage(data) {
+  try {
+    for (const entry of data.entry || []) {
+      for (const change of entry.changes || []) {
+        const value = change.value || {};
+        const messages = value.messages || [];
+        if (!messages.length) continue;
+        const msg = messages[0];
+        const sender = msg.from;
+        const type = msg.type;
+        if (type === 'text') {
+          const text = msg.text.body.trim().toLowerCase();
+          if (text === 'catalog') {
+            await sendCatalog(sender);
+          } else {
+            await sendTextMessage(sender, 'Unsupported command');
+          }
+        } else if (type === 'location') {
+          const { latitude, longitude } = msg.location;
+          await redisState.setLocation(sender, latitude, longitude);
+          const { within, branch } = isWithinDeliveryRadius(latitude, longitude);
+          if (within) {
+            await sendTextMessage(sender, `Nearest branch: ${branch}`);
+          } else {
+            await sendTextMessage(sender, 'Sorry, we do not deliver to your location');
+          }
+        } else if (type === 'order') {
+          const orderRes = await placeOrder(sender, 'Delivery');
+          if (orderRes.success) {
+            await sendOrderConfirmation(sender, orderRes.order_id);
+          }
+        }
+      }
+    }
+    return { status: 'ok' };
+  } catch (err) {
+    logger.error(`handleIncomingMessage error: ${err}`);
+    return { status: 'error' };
+  }
+}
+
+module.exports = { handleIncomingMessage };

--- a/handlers/webhookHandler.js
+++ b/handlers/webhookHandler.js
@@ -1,0 +1,23 @@
+const { handleIncomingMessage } = require('./messageHandler');
+const { getLogger } = require('../utils/logger');
+const logger = getLogger('webhook_handler');
+
+async function handleWebhook(req, res) {
+  logger.info('Webhook POST received');
+  const result = await handleIncomingMessage(req.body || {});
+  res.status(200).json(result);
+}
+
+function verifyWebhook(req, res) {
+  const verifyToken = process.env.META_VERIFY_TOKEN || 'verify';
+  const mode = req.query['hub.mode'];
+  const token = req.query['hub.verify_token'];
+  const challenge = req.query['hub.challenge'];
+  if (mode === 'subscribe' && token === verifyToken) {
+    res.status(200).send(challenge);
+  } else {
+    res.sendStatus(403);
+  }
+}
+
+module.exports = { handleWebhook, verifyWebhook };

--- a/package.json
+++ b/package.json
@@ -10,5 +10,10 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs"
+  "type": "commonjs",
+  "dependencies": {
+    "dotenv": "^16.0.0",
+    "express": "^4.18.2",
+    "ioredis": "^5.3.2"
+  }
 }

--- a/server.js
+++ b/server.js
@@ -1,26 +1,17 @@
-const http = require('http');
+const express = require('express');
+const { handleWebhook, verifyWebhook } = require('./handlers/webhookHandler');
 
-const server = http.createServer((req, res) => {
-  if (req.method === 'GET' && req.url === '/health') {
-    res.writeHead(200, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({ status: 'ok' }));
-  } else if (req.method === 'POST' && req.url === '/webhook') {
-    let body = '';
-    req.on('data', chunk => {
-      body += chunk;
-    });
-    req.on('end', () => {
-      // TODO: handle webhook logic
-      res.writeHead(200);
-      res.end();
-    });
-  } else {
-    res.writeHead(404);
-    res.end();
-  }
+const app = express();
+app.use(express.json());
+
+app.get('/health', (req, res) => {
+  res.json({ status: 'ok' });
 });
 
+app.get('/webhook', verifyWebhook);
+app.post('/webhook', handleWebhook);
+
 const PORT = process.env.PORT || 3000;
-server.listen(PORT, () => {
+app.listen(PORT, () => {
   console.log(`Server listening on ${PORT}`);
 });

--- a/services/orderService.js
+++ b/services/orderService.js
@@ -1,0 +1,102 @@
+const { BRANCH_COORDINATES, DELIVERY_RADIUS_KM, ORDER_STATUS, PRODUCT_CATALOG } = require('../config/settings');
+const redisState = require('../stateHandlers/redisState');
+const { getLogger } = require('../utils/logger');
+const logger = getLogger('order_service');
+
+function generateOrderId() {
+  return `ORD${Date.now().toString(36).toUpperCase()}`;
+}
+
+function toRad(v) {
+  return (v * Math.PI) / 180;
+}
+
+function calculateDistance(lat1, lon1, lat2, lon2) {
+  const R = 6371;
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(toRad(lat1)) *
+      Math.cos(toRad(lat2)) *
+      Math.sin(dLon / 2) *
+      Math.sin(dLon / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return R * c;
+}
+
+function findNearestBranch(lat, lon) {
+  let nearest = null;
+  let min = Infinity;
+  for (const [branch, coords] of Object.entries(BRANCH_COORDINATES)) {
+    const d = calculateDistance(lat, lon, coords[0], coords[1]);
+    if (d < min) {
+      min = d;
+      nearest = branch;
+    }
+  }
+  return { branch: nearest, distance: min };
+}
+
+function isWithinDeliveryRadius(lat, lon) {
+  const { branch, distance } = findNearestBranch(lat, lon);
+  return { within: distance <= DELIVERY_RADIUS_KM, branch, distance };
+}
+
+async function placeOrder(userId, deliveryType, address = null, paymentMethod = 'Cash on Delivery') {
+  const cart = await redisState.getCart(userId);
+  if (!cart.items.length) {
+    return { success: false, message: 'Cart is empty' };
+  }
+  const orderId = generateOrderId();
+  const order = {
+    order_id: orderId,
+    user_id: userId,
+    items: cart.items,
+    total: cart.total,
+    status: paymentMethod === 'Cash on Delivery' ? ORDER_STATUS.PAID : ORDER_STATUS.PENDING,
+    delivery_type: deliveryType,
+    delivery_address: address,
+    payment_method: paymentMethod,
+    order_date: new Date().toISOString()
+  };
+  await redisState.createOrder(order);
+  await redisState.clearCart(userId);
+  return { success: true, order_id: orderId };
+}
+
+async function processPayment(userId, orderId) {
+  logger.info(`Processing payment for ${userId} and order ${orderId}`);
+  // Real implementation would integrate with payment gateway
+  return { success: true };
+}
+
+async function updateOrderStatusFromCommand(command) {
+  const lower = command.toLowerCase();
+  let status = null;
+  if (lower.includes('ready')) status = ORDER_STATUS.READY;
+  else if (lower.includes('ontheway') || lower.includes('on the way')) status = ORDER_STATUS.ON_THE_WAY;
+  else if (lower.includes('delivered')) status = ORDER_STATUS.DELIVERED;
+  const parts = lower.split(/\s+/);
+  const orderId = parts[parts.length - 1].toUpperCase();
+  if (!status || !orderId) return { success: false, message: 'Invalid command' };
+  const ok = await redisState.updateOrderStatus(orderId, status);
+  return { success: ok };
+}
+
+async function confirmOrder(whatsappNumber, orderId, paymentMethod) {
+  logger.info(`Confirming order ${orderId} for ${whatsappNumber}`);
+  // Lookup pending order if needed and finalize
+  const success = true; // placeholder
+  return { success };
+}
+
+module.exports = {
+  generateOrderId,
+  findNearestBranch,
+  isWithinDeliveryRadius,
+  placeOrder,
+  processPayment,
+  updateOrderStatusFromCommand,
+  confirmOrder
+};

--- a/services/whatsappService.js
+++ b/services/whatsappService.js
@@ -1,0 +1,21 @@
+const { getLogger } = require('../utils/logger');
+const logger = getLogger('whatsapp_service');
+
+async function sendTextMessage(to, message) {
+  logger.info(`Sending message to ${to}: ${message}`);
+  // TODO: integrate with WhatsApp API
+}
+
+async function sendCatalog(to) {
+  logger.info(`Sending catalog to ${to}`);
+}
+
+async function sendOrderConfirmation(to, orderId) {
+  logger.info(`Sending order confirmation for ${orderId} to ${to}`);
+}
+
+module.exports = {
+  sendTextMessage,
+  sendCatalog,
+  sendOrderConfirmation
+};

--- a/stateHandlers/redisState.js
+++ b/stateHandlers/redisState.js
@@ -1,0 +1,108 @@
+const Redis = require('ioredis');
+const { REDIS_URL } = require('../config/redis');
+const { getLogger } = require('../utils/logger');
+
+const logger = getLogger('redis_state');
+
+class RedisState {
+  constructor() {
+    this.redis = new Redis(REDIS_URL);
+    this.redis.on('error', (err) => logger.error(`Redis error: ${err}`));
+  }
+
+  async getUserState(userId) {
+    try {
+      const data = await this.redis.get(`user:${userId}:state`);
+      return data ? JSON.parse(data) : null;
+    } catch (err) {
+      logger.error(`getUserState error: ${err}`);
+      return null;
+    }
+  }
+
+  async setUserState(userId, state) {
+    try {
+      state.lastUpdated = new Date().toISOString();
+      await this.redis.setex(`user:${userId}:state`, 3600, JSON.stringify(state));
+    } catch (err) {
+      logger.error(`setUserState error: ${err}`);
+    }
+  }
+
+  async clearUserState(userId) {
+    try {
+      await this.redis.del(`user:${userId}:state`);
+    } catch (err) {
+      logger.error(`clearUserState error: ${err}`);
+    }
+  }
+
+  async getCart(userId) {
+    try {
+      const data = await this.redis.get(`user:${userId}:cart`);
+      return data ? JSON.parse(data) : { items: [], total: 0 };
+    } catch (err) {
+      logger.error(`getCart error: ${err}`);
+      return { items: [], total: 0 };
+    }
+  }
+
+  async addToCart(userId, item) {
+    // item: { id, name, price, quantity }
+    const cart = await this.getCart(userId);
+    cart.items.push(item);
+    cart.total = cart.items.reduce((sum, i) => sum + i.price * i.quantity, 0);
+    await this.redis.setex(`user:${userId}:cart`, 86400, JSON.stringify(cart));
+    return cart;
+  }
+
+  async clearCart(userId) {
+    try {
+      await this.redis.del(`user:${userId}:cart`);
+    } catch (err) {
+      logger.error(`clearCart error: ${err}`);
+    }
+  }
+
+  async setLocation(userId, latitude, longitude) {
+    const cart = await this.getCart(userId);
+    cart.location = { latitude, longitude };
+    await this.redis.setex(`user:${userId}:cart`, 86400, JSON.stringify(cart));
+  }
+
+  async setBranch(userId, branch) {
+    const cart = await this.getCart(userId);
+    cart.branch = branch;
+    await this.redis.setex(`user:${userId}:cart`, 86400, JSON.stringify(cart));
+  }
+
+  async setPaymentMethod(userId, method) {
+    const cart = await this.getCart(userId);
+    cart.payment_method = method;
+    await this.redis.setex(`user:${userId}:cart`, 86400, JSON.stringify(cart));
+  }
+
+  async createOrder(order) {
+    await this.redis.rpush('orders:all', JSON.stringify(order));
+    await this.redis.setex(`order:${order.order_id}:active`, 604800, '1');
+  }
+
+  async getOrder(orderId) {
+    const all = await this.redis.lrange('orders:all', 0, -1);
+    for (const str of all) {
+      const o = JSON.parse(str);
+      if (o.order_id === orderId) return o;
+    }
+    return null;
+  }
+
+  async updateOrderStatus(orderId, status) {
+    const order = await this.getOrder(orderId);
+    if (!order) return false;
+    order.status = status;
+    await this.redis.rpush('orders:all', JSON.stringify(order));
+    return true;
+  }
+}
+
+module.exports = new RedisState();

--- a/utils/logger.js
+++ b/utils/logger.js
@@ -1,0 +1,9 @@
+function getLogger(name) {
+  return {
+    info: (msg) => console.log(`[${name}] ${msg}`),
+    error: (msg) => console.error(`[${name}] ${msg}`),
+    debug: (msg) => console.debug(`[${name}] ${msg}`)
+  };
+}
+
+module.exports = { getLogger };


### PR DESCRIPTION
## Summary
- scaffold Node.js server using Express with webhook and health routes
- add Redis state layer for cart, location, and order tracking
- include order and WhatsApp service stubs to mirror Python features

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_68a05a409c108327876565c0bc1e053f