### PR TITLE
feat: add cart reminder scheduler

### DIFF
--- a/schedulers/cartReminder.js
+++ b/schedulers/cartReminder.js
@@ -1,0 +1,34 @@
+const redisState = require('../stateHandlers/redisState');
+const { sendCartReminder } = require('../services/whatsappService');
+const { getLogger } = require('../utils/logger');
+
+const logger = getLogger('cart_reminder');
+
+async function checkCartReminders() {
+  const users = await redisState.getUsersWithCarts();
+  const now = new Date();
+  const today = now.toISOString().slice(0, 10);
+
+  for (const userId of users) {
+    const cart = await redisState.getCart(userId);
+    if (!cart.items || cart.items.length === 0) {
+      await redisState.clearCart(userId);
+      continue;
+    }
+    if (!cart.lastAdded) continue;
+    const lastAdded = new Date(cart.lastAdded);
+    const diffMs = now - lastAdded;
+    if (diffMs >= 60 * 60 * 1000 && cart.lastReminderDate !== today) {
+      await sendCartReminder(userId, cart);
+      await redisState.markCartReminderSent(userId, today);
+      logger.info(`Sent cart reminder to ${userId}`);
+    }
+  }
+}
+
+function startCartReminderScheduler() {
+  setInterval(checkCartReminders, 60 * 1000);
+  logger.info('Cart reminder scheduler started');
+}
+
+module.exports = { startCartReminderScheduler };

--- a/server.js
+++ b/server.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const { handleWebhook, verifyWebhook } = require('./handlers/webhookHandler');
+const { startCartReminderScheduler } = require('./schedulers/cartReminder');
 
 const app = express();
 app.use(express.json());
@@ -15,3 +16,5 @@ const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {
   console.log(`Server listening on ${PORT}`);
 });
+
+startCartReminderScheduler();

--- a/services/whatsappService.js
+++ b/services/whatsappService.js
@@ -14,8 +14,15 @@ async function sendOrderConfirmation(to, orderId) {
   logger.info(`Sending order confirmation for ${orderId} to ${to}`);
 }
 
+async function sendCartReminder(to, cart) {
+  const items = cart.items.map(i => `${i.quantity} x ${i.name}`).join(', ');
+  const message = `You have items waiting in your cart: ${items}. Complete your order!`;
+  await sendTextMessage(to, message);
+}
+
 module.exports = {
   sendTextMessage,
   sendCatalog,
-  sendOrderConfirmation
+  sendOrderConfirmation,
+  sendCartReminder
 };


### PR DESCRIPTION
## Summary
- track cart activity and last reminder dates in Redis
- send daily cart reminders one hour after items are added
- wire scheduler into server startup and WhatsApp service

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a05cba9c488327abe18c92226a0afd