### PR TITLE
Add payment success and Razorpay webhook handling

### DIFF
--- a/handlers/paymentWebhook.js
+++ b/handlers/paymentWebhook.js
@@ -1,0 +1,47 @@
+const crypto = require('crypto');
+const { confirmOrder } = require('../services/orderService');
+const { sendTextMessage } = require('../services/whatsappService');
+const { getLogger } = require('../utils/logger');
+
+const logger = getLogger('payment_webhook');
+
+function verifySignature(rawBody, signature, secret) {
+  const expected = crypto
+    .createHmac('sha256', secret)
+    .update(rawBody)
+    .digest('hex');
+  return expected === signature;
+}
+
+async function handlePaymentWebhook(req, res) {
+  const signature = req.get('X-Razorpay-Signature');
+  const secret = process.env.RAZORPAY_WEBHOOK_SECRET;
+  if (!signature || !secret || !verifySignature(req.rawBody, signature, secret)) {
+    logger.warn('Invalid Razorpay signature');
+    res.status(400).send('Invalid signature');
+    return;
+  }
+
+  const data = req.body || {};
+  if (data.event === 'payment_link.paid') {
+    const payment = data.payload?.payment_link?.entity || {};
+    const whatsapp = payment.customer?.contact;
+    const orderId = payment.reference_id;
+
+    if (whatsapp && orderId) {
+      try {
+        await sendTextMessage(
+          whatsapp,
+          '✅ Your payment is confirmed! Your order is being processed.'
+        );
+        await confirmOrder(whatsapp, orderId, 'Online');
+      } catch (err) {
+        logger.error(`Payment webhook processing failed: ${err.message}`);
+      }
+    }
+  }
+
+  res.send('OK');
+}
+
+module.exports = { handlePaymentWebhook };

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ require('dotenv').config();
 const express = require('express');
 const { handleWebhook, verifyWebhook } = require('./handlers/webhookHandler');
 const { handlePaymentSuccess } = require('./handlers/paymentSuccess');
+const { handlePaymentWebhook } = require('./handlers/paymentWebhook');
 const { startCartReminderScheduler } = require('./schedulers/cartReminder');
 const { startReminderScheduler } = require('./schedulers/reminderScheduler');
 const { getLogger } = require('./utils/logger');
@@ -9,7 +10,13 @@ const { getLogger } = require('./utils/logger');
 const logger = getLogger('server');
 
 const app = express();
-app.use(express.json());
+app.use(
+  express.json({
+    verify: (req, res, buf) => {
+      req.rawBody = buf;
+    }
+  })
+);
 
 app.get('/health', (req, res) => {
   res.json({ status: 'ok' });
@@ -18,6 +25,7 @@ app.get('/health', (req, res) => {
 app.get('/webhook', verifyWebhook);
 app.post('/webhook', handleWebhook);
 app.get('/payment-success', handlePaymentSuccess);
+app.post('/payment-made', handlePaymentWebhook);
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {

--- a/utils/paymentUtils.js
+++ b/utils/paymentUtils.js
@@ -19,7 +19,11 @@ async function generateRazorpayLink(amount, orderId) {
         amount: paise,
         currency: 'INR',
         reference_id: orderId,
-        description: `Payment for order ${orderId}`
+        description: `Payment for order ${orderId}`,
+        callback_url:
+          process.env.PAYMENT_SUCCESS_URL ||
+          'https://example.com/payment-success',
+        callback_method: 'get'
       })
     });
     const data = await res.json();

--- a/utils/payment_utils.py
+++ b/utils/payment_utils.py
@@ -44,7 +44,7 @@ def generate_payment_link(to, total, order_id, max_retries=3, delay=1):
             "email": False
         },
         "reminder_enable": True,
-        "callback_url": "https://yourdomain.com/razorpay-webhook",
+        "callback_url": "https://yourdomain.com/payment-success",
         "callback_method": "get"
     }
 


### PR DESCRIPTION
## Summary
- include callback URL when generating Razorpay payment links
- verify Razorpay signatures and confirm orders in new `/payment-made` webhook
- expose Razorpay webhook endpoint on the Express server

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a07543f8dc83278c39b8f7a18c5743