### PR TITLE
Include customer contact in Razorpay links and verify webhooks

### DIFF
--- a/server.js
+++ b/server.js
@@ -13,7 +13,8 @@ const app = express();
 app.use(
   express.json({
     verify: (req, res, buf) => {
-      req.rawBody = buf;
+      // Store the raw request body for Razorpay signature verification
+      req.rawBody = buf.toString();
     }
   })
 );

--- a/services/orderService.js
+++ b/services/orderService.js
@@ -92,7 +92,7 @@ async function placeOrder(userId, deliveryType, address = null, paymentMethod = 
   };
 
   if (paymentMethod !== 'Cash on Delivery') {
-    order.payment_link = await generateRazorpayLink(total, orderId);
+    order.payment_link = await generateRazorpayLink(total, orderId, userId);
   }
 
   await redisState.createOrder(order);
@@ -127,7 +127,7 @@ async function processPayment(userId, orderId) {
     return { success: false, message: 'Order not found' };
   }
   try {
-    const link = await generateRazorpayLink(order.total, orderId);
+    const link = await generateRazorpayLink(order.total, orderId, userId);
     order.payment_link = link;
     return { success: true, payment_link: link };
   } catch (err) {


### PR DESCRIPTION
## Summary
- attach customer phone and notification options when creating Razorpay payment links
- pass user ID to payment link generator so webhook contains the contact
- keep raw request body for signature verification of Razorpay webhooks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0842982cc8327a081297b74a0fcc6