### PR TITLE
feat: add simple chat interface

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Kanuka Chat</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" />
+  <link rel="stylesheet" href="/styles.css" />
+</head>
+<body>
+  <div class="container py-4">
+    <h1 class="text-center mb-4">Kanuka Chat</h1>
+    <div id="chat" class="border rounded p-3 mb-3 bg-light chat-box"></div>
+    <div class="input-group">
+      <input type="text" id="messageInput" class="form-control" placeholder="Type your message..." />
+      <button id="sendBtn" class="btn btn-primary">Send</button>
+    </div>
+  </div>
+  <script src="/script.js"></script>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,38 @@
+const chat = document.getElementById('chat');
+const input = document.getElementById('messageInput');
+const sendBtn = document.getElementById('sendBtn');
+
+function addMessage(text, type) {
+  const div = document.createElement('div');
+  div.className = `message ${type}`;
+  div.textContent = text;
+  chat.appendChild(div);
+  chat.scrollTop = chat.scrollHeight;
+}
+
+async function sendMessage() {
+  const text = input.value.trim();
+  if (!text) return;
+  addMessage(text, 'sent');
+  input.value = '';
+  try {
+    const res = await fetch('/message', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: text })
+    });
+    const data = await res.json();
+    if (data.reply) {
+      addMessage(data.reply, 'received');
+    }
+  } catch (err) {
+    addMessage('Error sending message', 'received');
+  }
+}
+
+sendBtn.addEventListener('click', sendMessage);
+input.addEventListener('keypress', (e) => {
+  if (e.key === 'Enter') {
+    sendMessage();
+  }
+});

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,28 @@
+body {
+  background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
+  min-height: 100vh;
+}
+
+.chat-box {
+  height: 60vh;
+  overflow-y: auto;
+  background-color: #ffffff;
+}
+
+.message {
+  padding: 8px 12px;
+  margin-bottom: 10px;
+  border-radius: 20px;
+  max-width: 75%;
+}
+
+.message.sent {
+  background-color: #0d6efd;
+  color: #fff;
+  margin-left: auto;
+}
+
+.message.received {
+  background-color: #e9ecef;
+  margin-right: auto;
+}

--- a/server.js
+++ b/server.js
@@ -1,5 +1,6 @@
 require('dotenv').config();
 const express = require('express');
+const path = require('path');
 const { handleWebhook, verifyWebhook } = require('./handlers/webhookHandler');
 const { handlePaymentSuccess } = require('./handlers/paymentSuccess');
 const { handlePaymentWebhook } = require('./handlers/paymentWebhook');
@@ -19,6 +20,14 @@ app.use(
   })
 );
 
+// Serve static assets for chat interface
+app.use(express.static(path.join(__dirname, 'public')));
+
+// Basic route to serve the chat page
+app.get('/', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'index.html'));
+});
+
 app.get('/health', (req, res) => {
   res.json({ status: 'ok' });
 });
@@ -27,6 +36,12 @@ app.get('/webhook', verifyWebhook);
 app.post('/webhook', handleWebhook);
 app.get('/payment-success', handlePaymentSuccess);
 app.post('/payment-made', handlePaymentWebhook);
+
+// Simple endpoint to echo chat messages
+app.post('/message', (req, res) => {
+  const { message } = req.body || {};
+  res.json({ reply: `Echo: ${message || ''}` });
+});
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- serve static chat UI via Express for a more engaging experience
- add modern HTML/CSS/JS chat page with Bootstrap styling
- provide echo API for basic message interaction

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a087a4539883278a94da7d555a13ce