### PR TITLE
feat: support brand-specific WhatsApp credentials

### DIFF
--- a/config/brandConfig.js
+++ b/config/brandConfig.js
@@ -16,10 +16,13 @@ function getBrandInfoByPhoneId(phoneNumberId) {
     throw new Error(`No brand configured for phone_number_id ${phoneNumberId}`);
   }
   const brandConfig = loadBrand(entry.brand_id);
+  const catalogId = process.env[entry.catalog_id_env];
+  const accessToken = process.env[entry.access_token_env];
   return {
     brandConfig,
     phoneNumberId,
-    catalogId: entry.catalog_id
+    catalogId,
+    accessToken
   };
 }
 

--- a/config/brandPhones.json
+++ b/config/brandPhones.json
@@ -2,11 +2,13 @@
   "747499348442635": {
     "brand_id": "kanuka",
     "display_phone_number": "917989884303",
-    "catalog_id": "CATALOG_KANUKA"
+    "catalog_id_env": "CATALOG_ID_KANUKA",
+    "access_token_env": "META_ACCESS_TOKEN_KANUKA"
   },
   "9876543210": {
     "brand_id": "zumi",
     "display_phone_number": "987654321",
-    "catalog_id": "CATALOG_ZUMI"
+    "catalog_id_env": "CATALOG_ID_ZUMI",
+    "access_token_env": "META_ACCESS_TOKEN_ZUMI"
   }
 }

--- a/config/credentials.py
+++ b/config/credentials.py
@@ -1,51 +1,51 @@
+import os
 
 
-# META_ACCESS_TOKEN = "EAASgG9eRTmYBPJ7Takvau9H1RLk3UTEkrevSPfqhWKXmkqLhaip6GeBYKrDhrol5Q91JRi4DaeZCmkgIMTIKKkA2VBt4csl7l05JAt8aUOSvwjvFS26gPUYbDBja6RpBpxybgX0byLXFsW8lkgDYkh0ieJFKCFFheVH0IZCFwq8fwc8AQPxLrZAqlip0igo"
-# META_PHONE_NUMBER_ID = "747499348442635"
-# META_VERIFY_TOKEN = "kanuka123"
-# GOOGLE_MAPS_API_KEY = "AIzaSyCuUz9N78WZAT1N38ffIDkbySI3_0zkZgE"
-# RAZORPAY_KEY_ID = "rzp_live_jtGMQ5k5QGHxFg"
-# RAZORPAY_KEY_SECRET = "FEMHAO4zeUFnAiKZPLe44NRN"
-# WHATSAPP_API_URL = f"https://graph.facebook.com/v23.0/{META_PHONE_NUMBER_ID}/messages" 
-# CATALOG_ID = "1454851805648535"
-# CATALOG_ID_FOR_MATCHED_ITEMS = "1454851805648535"
+def load_brand_credentials(brand_id: str | None = None) -> dict:
+    """Load brand-specific credentials from environment variables.
+
+    Credentials are expected to follow the pattern
+    META_ACCESS_TOKEN_<BRAND>, META_PHONE_NUMBER_ID_<BRAND>, and
+    CATALOG_ID_<BRAND>. The brand identifier is upper-cased before
+    lookup. If no brand_id is supplied, the BRAND_ID environment
+    variable is used.
+    """
+
+    brand = (brand_id or os.getenv("BRAND_ID", "")).upper()
+
+    access_token = os.getenv(f"META_ACCESS_TOKEN_{brand}")
+    phone_number_id = os.getenv(f"META_PHONE_NUMBER_ID_{brand}")
+    catalog_id = os.getenv(f"CATALOG_ID_{brand}")
+    verify_token = os.getenv("META_VERIFY_TOKEN")
+
+    whatsapp_api_url = (
+        f"https://graph.facebook.com/v23.0/{phone_number_id}/messages"
+        if phone_number_id
+        else None
+    )
+
+    return {
+        "META_ACCESS_TOKEN": access_token,
+        "META_PHONE_NUMBER_ID": phone_number_id,
+        "WHATSAPP_CATALOG_ID": catalog_id,
+        "META_VERIFY_TOKEN": verify_token,
+        "WHATSAPP_API_URL": whatsapp_api_url,
+    }
 
 
-# config/credentials.py
-# import os
-
-# class Credentials:
-#     REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
-#     RAZORPAY_KEY = os.getenv("RAZORPAY_KEY")
-#     RAZORPAY_SECRET = os.getenv("RAZORPAY_SECRET")
-#     WHATSAPP_TOKEN = os.getenv("META_ACCESS_TOKEN")
-#     WHATSAPP_API_URL = os.getenv("WHATSAPP_API_URL")
-#     PHONE_NUMBER_ID = os.getenv("META_PHONE_NUMBER_ID")
-#     VERIFY_TOKEN = os.getenv("META_VERIFY_TOKEN")
-#     ADMIN_PHONE = os.getenv("ADMIN_PHONE")  # For order alerts
-#     CATALOG_ID = os.getenv("CATALOG_ID")  # For order alerts
-#     CATALOG_ID_FOR_MATCHED_ITEMS = os.getenv("CATALOG_ID_FOR_MATCHED_ITEMS")  # For order alerts
+_creds = load_brand_credentials()
+META_ACCESS_TOKEN = _creds["META_ACCESS_TOKEN"]
+META_PHONE_NUMBER_ID = _creds["META_PHONE_NUMBER_ID"]
+WHATSAPP_CATALOG_ID = _creds["WHATSAPP_CATALOG_ID"]
+META_VERIFY_TOKEN = _creds["META_VERIFY_TOKEN"]
+WHATSAPP_API_URL = _creds["WHATSAPP_API_URL"]
 
 
-# config/credentials.py
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+RAZORPAY_KEY_ID = os.getenv("RAZORPAY_KEY_ID")
+RAZORPAY_KEY_SECRET = os.getenv("RAZORPAY_KEY_SECRET")
+GOOGLE_MAPS_API_KEY = os.getenv("GOOGLE_MAPS_API_KEY")
 
-# WhatsApp API credentials
-META_ACCESS_TOKEN = "EAASgG9eRTmYBPDaWHO0wdumCZAiyit9vcDw6iCYwHvEqZBdyHhVliAB3l7GKtu9MHALhHtiotjr1LMQaS1bn9YcMZAkSBPtq5RHALpSAGwV6DQscMqIbanejXN3JfXlngqZBSxuvHewHOBzGVruDYYA6Fl7m5nPMZAbDvnGSvMQUvZBxn3IykpjCl3crVg"
-META_PHONE_NUMBER_ID = "747499348442635"
-WHATSAPP_API_URL = f"https://graph.facebook.com/v23.0/{META_PHONE_NUMBER_ID}/messages"
-WHATSAPP_CATALOG_ID = "1454851805648535"  # Optional, if using WhatsApp Catalog
-
-# Verification token for webhook
-META_VERIFY_TOKEN = "kanuka123"
-
-# Redis connection
-REDIS_URL = "redis://localhost:6379/0"
-
-# Razorpay credentials
-RAZORPAY_KEY_ID = "rzp_live_jtGMQ5k5QGHxFg"
-RAZORPAY_KEY_SECRET = "FEMHAO4zeUFnAiKZPLe44NRN"
-
-GOOGLE_MAPS_API_KEY = "AIzaSyCuUz9N78WZAT1N38ffIDkbySI3_0zkZgE"
 
 # CSV file paths (relative to project root)
 ORDERS_CSV = "../data/orders.csv"
@@ -53,3 +53,4 @@ CART_REMINDERS_CSV = "../data/cart_reminders.csv"
 USER_ACTIVITY_LOG_CSV = "../data/user_activity_log.csv"
 BRANCHES_CSV = "../data/branches.csv"
 BRANDS_CSV = "../data/brands.csv"
+

--- a/handlers/messageHandler.js
+++ b/handlers/messageHandler.js
@@ -192,10 +192,13 @@ async function handleIncomingMessage(data) {
         const sender = msg.from;
         const type = msg.type;
         const metadata = value.metadata || {};
-        const { brandConfig, phoneNumberId, catalogId } = getBrandInfoByPhoneId(
-          metadata.phone_number_id
-        );
-        setBrandContext(brandConfig, phoneNumberId, catalogId);
+        const {
+          brandConfig,
+          phoneNumberId,
+          catalogId,
+          accessToken,
+        } = getBrandInfoByPhoneId(metadata.phone_number_id);
+        setBrandContext(brandConfig, phoneNumberId, catalogId, accessToken);
         setBrandCatalog(brandConfig);
         const state = (await redisState.getUserState(sender)) || {};
 

--- a/services/whatsappService.js
+++ b/services/whatsappService.js
@@ -8,14 +8,16 @@ const logger = getLogger('whatsapp_service');
 let brandConfig = { name: 'Kanuka Organics', catalog: [] };
 let phoneNumberId = process.env.META_PHONE_NUMBER_ID;
 let catalogId = process.env.CATALOG_ID;
+let accessToken = process.env.META_ACCESS_TOKEN;
 let WHATSAPP_API_URL = phoneNumberId
   ? `https://graph.facebook.com/v23.0/${phoneNumberId}/messages`
   : null;
 
-function setBrandContext(config, phoneId, catId) {
+function setBrandContext(config, phoneId, catId, token) {
   brandConfig = config || brandConfig;
   phoneNumberId = phoneId || phoneNumberId;
   catalogId = catId || catalogId;
+  accessToken = token || accessToken;
   WHATSAPP_API_URL = `https://graph.facebook.com/v23.0/${phoneNumberId}/messages`;
 }
 
@@ -32,7 +34,7 @@ async function sendTextMessage(to, message) {
     const res = await fetch(WHATSAPP_API_URL, {
       method: 'POST',
       headers: {
-        Authorization: `Bearer ${process.env.META_ACCESS_TOKEN}`,
+        Authorization: `Bearer ${accessToken}`,
         'Content-Type': 'application/json'
       },
       body: JSON.stringify(payload)
@@ -72,14 +74,14 @@ async function sendCatalog(to) {
   };
 
   try {
-    const res = await fetch(WHATSAPP_API_URL, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${process.env.META_ACCESS_TOKEN}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(payload),
-    });
+      const res = await fetch(WHATSAPP_API_URL, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      });
     logger.info(`Catalog template sent. Status: ${res.status}`);
     if (!res.ok) {
       const errText = await res.text();
@@ -150,7 +152,7 @@ async function sendMainMenu(to) {
     const res = await fetch(WHATSAPP_API_URL, {
       method: 'POST',
       headers: {
-        Authorization: `Bearer ${process.env.META_ACCESS_TOKEN}`,
+        Authorization: `Bearer ${accessToken}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(payload),
@@ -210,7 +212,7 @@ async function sendCartSummary(to, cart) {
     const res = await fetch(WHATSAPP_API_URL, {
       method: 'POST',
       headers: {
-        Authorization: `Bearer ${process.env.META_ACCESS_TOKEN}`,
+        Authorization: `Bearer ${accessToken}`,
         'Content-Type': 'application/json'
       },
       body: JSON.stringify(payload)
@@ -258,7 +260,7 @@ async function sendPaymentOptions(to) {
     const res = await fetch(WHATSAPP_API_URL, {
       method: 'POST',
       headers: {
-        Authorization: `Bearer ${process.env.META_ACCESS_TOKEN}`,
+        Authorization: `Bearer ${accessToken}`,
         'Content-Type': 'application/json'
       },
       body: JSON.stringify(payload)
@@ -307,7 +309,7 @@ async function sendBranchSelection(to, branches) {
     const res = await fetch(WHATSAPP_API_URL, {
       method: 'POST',
       headers: {
-        Authorization: `Bearer ${process.env.META_ACCESS_TOKEN}`,
+        Authorization: `Bearer ${accessToken}`,
         'Content-Type': 'application/json'
       },
       body: JSON.stringify(payload)
@@ -347,7 +349,7 @@ async function sendPaymentLink(to, link) {
     const res = await fetch(WHATSAPP_API_URL, {
       method: 'POST',
       headers: {
-        Authorization: `Bearer ${process.env.META_ACCESS_TOKEN}`,
+        Authorization: `Bearer ${accessToken}`,
         'Content-Type': 'application/json'
       },
       body: JSON.stringify(payload)


### PR DESCRIPTION
## Summary
- load per-brand WhatsApp tokens and catalog IDs from environment
- pass resolved credentials through brand config to WhatsApp service
- use brand-specific access tokens for outbound WhatsApp API calls

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0bb27dfb88327b9b99da83e647023