### PR TITLE
fix: fallback to config tokens when env vars missing

### DIFF
--- a/config/brandConfig.js
+++ b/config/brandConfig.js
@@ -16,8 +16,8 @@ function getBrandInfoByPhoneId(phoneNumberId) {
     throw new Error(`No brand configured for phone_number_id ${phoneNumberId}`);
   }
   const brandConfig = loadBrand(entry.brand_id);
-  const catalogId = process.env[entry.catalog_id_env];
-  const accessToken = process.env[entry.access_token_env];
+  const catalogId = process.env[entry.catalog_id_env] || entry.catalog_id_env;
+  const accessToken = process.env[entry.access_token_env] || entry.access_token_env;
   return {
     brandConfig,
     phoneNumberId,


### PR DESCRIPTION
## Summary
- allow brand config loader to use catalog IDs and access tokens from configuration files when environment variables are not set

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0c0b1844483279173d6e46586be23