### PR TITLE
feat: make catalog greeting configurable per brand

### DIFF
--- a/config/brands/kanuka.json
+++ b/config/brands/kanuka.json
@@ -5,6 +5,7 @@
     "phone": "+919226454238",
     "email": "hello@kanukaorganics.com"
   },
+  "catalog_message": "🌟 *Explore Our Organic Products* 🌿\n\n",
   "catalog": [
     {
       "id": "6xpxtkaoau",

--- a/config/brands/zumi.json
+++ b/config/brands/zumi.json
@@ -5,6 +5,7 @@
     "phone": "+919876543210",
     "email": "hello@zumi.com"
   },
+  "catalog_message": "🍹 *Explore Our Refreshing Drinks* 🍹\n\n",
   "catalog": [
     {
       "id": "w4w37b2azl",

--- a/services/whatsappService.js
+++ b/services/whatsappService.js
@@ -53,9 +53,11 @@ async function sendTextMessage(to, message) {
 
 async function sendCatalog(to) {
   logger.info(`Sending catalog to ${to}`);
+  const greeting =
+    brandConfig.catalog_message || '🌟 *Explore Our Organic Products* 🌿\\n\\n';
   const message =
-    '🌟 *Explore Our Organic Products* 🌿\n\n' +
-    'Browse our catalog and add your favourites to the cart.\n\n' +
+    greeting +
+    'Browse our catalog and add your favourites to the cart.\\n\\n' +
     '👇 Tap below to get started!';
 
   const payload = {


### PR DESCRIPTION
## Summary
- allow brand-specific catalog greeting
- configure greeting for Kanuka and Zumi

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0c2e41e64832783dc48d7b4158ab0