### PR TITLE
Handle brand-specific Razorpay webhook secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ that receives the message. The mapping from `phone_number_id` values to brand
 configurations is defined in `config/brandPhones.json`. Each entry also stores the
 corresponding `catalog_id` required by the Meta API.
 
+### Razorpay webhooks
+
+Each brand requires its own Razorpay webhook secret. Configure an environment
+variable `RAZORPAY_WEBHOOK_SECRET_<BRAND>` for every brand (e.g.
+`RAZORPAY_WEBHOOK_SECRET_KANUKA`). The `/payment-made` endpoint will validate
+incoming webhooks against these secrets to determine the correct brand context.
+Set the same secret in the Razorpay dashboard when creating each brand's webhook.
+
 Two sample brands are included:
 
 - `kanuka` mapped to `phone_number_id` `747499348442635`

--- a/test/paymentWebhook.test.js
+++ b/test/paymentWebhook.test.js
@@ -1,0 +1,31 @@
+const test = require('node:test');
+const assert = require('assert');
+const crypto = require('crypto');
+
+process.env.RAZORPAY_WEBHOOK_SECRET_KANUKA = 'secretkanuka';
+process.env.RAZORPAY_WEBHOOK_SECRET_ZUMI = 'secretzumi';
+
+const { getBrandIdFromSignature } = require('../handlers/paymentWebhook');
+
+test('getBrandIdFromSignature selects correct brand based on signature', () => {
+  const payload = JSON.stringify({ test: true });
+  const sig = crypto
+    .createHmac('sha256', 'secretzumi')
+    .update(payload)
+    .digest('hex');
+
+  const brand = getBrandIdFromSignature(payload, sig);
+  assert.strictEqual(brand, 'zumi');
+});
+
+test('getBrandIdFromSignature returns null for unknown signature', () => {
+  const payload = JSON.stringify({ test: true });
+  const sig = crypto
+    .createHmac('sha256', 'invalidsecret')
+    .update(payload)
+    .digest('hex');
+
+  const brand = getBrandIdFromSignature(payload, sig);
+  assert.strictEqual(brand, null);
+});
+


### PR DESCRIPTION
## Summary
- document per-brand Razorpay webhook secrets
- verify webhook signatures against brand-specific secrets and configure WhatsApp context
- test that correct brand is selected from signature

## Testing
- `npm test` *(fails: Redis error: connect ECONNREFUSED 127.0.0.1:6379)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c4e252208327860abe79657db9e0