### PR TITLE
Isolate Redis state per brand

### DIFF
--- a/services/orderService.js
+++ b/services/orderService.js
@@ -56,7 +56,7 @@ async function placeOrder(
   paymentMethod = 'Cash on Delivery',
   brandId
 ) {
-  const cart = await redisState.getCart(userId);
+  const cart = await redisState.getCart(userId, brandId);
   if (!cart.items.length) {
     return { success: false, message: 'Cart is empty' };
   }
@@ -122,7 +122,7 @@ async function placeOrder(
     }
   }
 
-  await redisState.clearCart(userId);
+  await redisState.clearCart(userId, brandId);
   return { success: true, order_id: orderId, payment_link: order.payment_link };
 }
 


### PR DESCRIPTION
## Summary
- Pass brand identifiers into all Redis state operations to isolate carts and user states per WhatsApp brand.
- Update message handler and order service to supply the brand ID so cross-brand interactions no longer bleed state.

## Testing
- `npm test` *(fails: connect ECONNREFUSED 127.0.0.1:6379)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d6789f5c8327bc1d82abc84f1881