### PR TITLE
Fix cart reminder brand context and add interactive actions

### DIFF
--- a/schedulers/cartReminder.js
+++ b/schedulers/cartReminder.js
@@ -1,18 +1,30 @@
 const redisState = require('../stateHandlers/redisState');
-const { sendCartReminder } = require('../services/whatsappService');
+const { sendCartReminder, setBrandContext } = require('../services/whatsappService');
+const { setBrandCatalog } = require('../config/settings');
+const { getBrandInfoByPhoneId } = require('../config/brandConfig');
 const { getLogger } = require('../utils/logger');
 
 const logger = getLogger('cart_reminder');
 
 async function checkCartReminders() {
-  const users = await redisState.getUsersWithCarts();
+  const {
+    brandConfig,
+    brandId,
+    phoneNumberId,
+    catalogId,
+    accessToken,
+  } = getBrandInfoByPhoneId(process.env.META_PHONE_NUMBER_ID);
+  setBrandContext(brandConfig, phoneNumberId, catalogId, accessToken);
+  setBrandCatalog(brandConfig);
+
+  const users = await redisState.getUsersWithCarts(brandId);
   const now = new Date();
   const today = now.toISOString().slice(0, 10);
 
   for (const userId of users) {
-    const cart = await redisState.getCart(userId);
+    const cart = await redisState.getCart(userId, brandId);
     if (!cart.items || cart.items.length === 0) {
-      await redisState.clearCart(userId);
+      await redisState.clearCart(userId, brandId);
       continue;
     }
     if (!cart.lastAdded) continue;
@@ -20,7 +32,7 @@ async function checkCartReminders() {
     const diffMs = now - lastAdded;
     if (diffMs >= 60 * 60 * 1000 && cart.lastReminderDate !== today) {
       await sendCartReminder(userId, cart);
-      await redisState.markCartReminderSent(userId, today);
+      await redisState.markCartReminderSent(userId, today, brandId);
       logger.info(`Sent cart reminder to ${userId}`);
     }
   }


### PR DESCRIPTION
## Summary
- ensure cart reminder scheduler resets brand context and uses brand-specific keys
- upgrade cart reminder message with interactive buttons for checkout or continued shopping

## Testing
- `npm test` *(fails: connect ECONNREFUSED 127.0.0.1:6379)*

------
https://chatgpt.com/codex/tasks/task_e_68a1701d69988327a19262036e1b5c0e