### PR TITLE
feat: add default Razorpay webhook secret

### DIFF
--- a/test/paymentWebhook.test.js
+++ b/test/paymentWebhook.test.js
@@ -1,6 +1,7 @@
 const test = require('node:test');
 const assert = require('assert');
 const crypto = require('crypto');
+const fs = require('fs');
 
 process.env.RAZORPAY_WEBHOOK_SECRET_KANUKA = 'secretkanuka';
 process.env.RAZORPAY_WEBHOOK_SECRET_ZUMI = 'secretzumi';
@@ -16,6 +17,23 @@ test('getBrandIdFromSignature selects correct brand based on signature', () => {
 
   const brand = getBrandIdFromSignature(payload, sig);
   assert.strictEqual(brand, 'zumi');
+});
+
+test('getBrandIdFromSignature falls back to default secret', () => {
+  const payload = JSON.stringify({ test: true });
+  const sig = crypto
+    .createHmac('sha256', 'secretkanuka')
+    .update(payload)
+    .digest('hex');
+
+  const original = fs.readdirSync;
+  fs.readdirSync = () => ['zumi.json'];
+  try {
+    const brand = getBrandIdFromSignature(payload, sig);
+    assert.strictEqual(brand, 'kanuka');
+  } finally {
+    fs.readdirSync = original;
+  }
 });
 
 test('getBrandIdFromSignature returns null for unknown signature', () => {


### PR DESCRIPTION
## Summary
- fallback to default `RAZORPAY_WEBHOOK_SECRET_KANUKA` when brand-specific secret is missing or doesn't match
- ignore payments with invalid signatures after fallback
- cover default secret logic with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a18b4028708327bada700088b80949