### PR TITLE
Handle missing Razorpay webhook secret

### DIFF
--- a/handlers/paymentWebhook.js
+++ b/handlers/paymentWebhook.js
@@ -25,6 +25,12 @@ async function handlePaymentWebhook(req, res) {
   const { setBrandCatalog } = require('../config/settings');
   const signature = req.get('X-Razorpay-Signature');
   const secret = process.env.RAZORPAY_WEBHOOK_SECRET;
+  if (!secret) {
+    logger.error('Razorpay webhook secret is not configured');
+    res.status(500).send('Server misconfigured');
+    return;
+  }
+
   if (!signature || !verifySignature(req.rawBody, signature, secret)) {
     logger.warn('Invalid Razorpay signature, ignoring payment');
     res.status(200).send('Ignored');


### PR DESCRIPTION
## Summary
- avoid TypeError when Razorpay webhook secret is not set by checking env var before verifying signature

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2130240b0832796d16420d1daf097