### PR TITLE
Handle missing webhook secret

### DIFF
--- a/handlers/paymentWebhook.js
+++ b/handlers/paymentWebhook.js
@@ -11,6 +11,9 @@ function getRedis() {
 const logger = getLogger('payment_webhook');
 
 function verifySignature(rawBody, signature, secret) {
+  if (!secret || !rawBody || !signature) {
+    return false;
+  }
   const expected = crypto
     .createHmac('sha256', secret)
     .update(rawBody)

--- a/test/paymentWebhook.test.js
+++ b/test/paymentWebhook.test.js
@@ -16,3 +16,10 @@ test('verifySignature rejects incorrect signature', () => {
   const sig = crypto.createHmac('sha256', 'wrong').update(payload).digest('hex');
   assert.ok(!verifySignature(payload, sig, secret));
 });
+
+test('verifySignature returns false when secret is missing', () => {
+  const payload = JSON.stringify({ ok: true });
+  const secret = undefined;
+  const sig = crypto.createHmac('sha256', 'secret').update(payload).digest('hex');
+  assert.strictEqual(verifySignature(payload, sig, secret), false);
+});


### PR DESCRIPTION
## Summary
- avoid crashing when Razorpay webhook secret is undefined
- add test for missing webhook secret

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2188dae9c8327b4df0de17a7cbadb