### PR TITLE
Use single Razorpay webhook secret and notify brand-specific orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,10 @@ corresponding `catalog_id` required by the Meta API.
 
 ### Razorpay webhooks
 
-Each brand requires its own Razorpay webhook secret. Configure an environment
-variable `RAZORPAY_WEBHOOK_SECRET_<BRAND>` for every brand (e.g.
-`RAZORPAY_WEBHOOK_SECRET_KANUKA`). The `/payment-made` endpoint will validate
-incoming webhooks against these secrets to determine the correct brand context.
-Set the same secret in the Razorpay dashboard when creating each brand's webhook.
+Configure a single environment variable `RAZORPAY_WEBHOOK_SECRET` used to
+validate all incoming Razorpay webhooks. Set the same secret in the Razorpay
+dashboard when creating the webhook. The handler will determine the correct
+brand based on the order associated with each payment.
 
 Two sample brands are included:
 

--- a/handlers/paymentWebhook.js
+++ b/handlers/paymentWebhook.js
@@ -48,7 +48,15 @@ async function handlePaymentWebhook(req, res) {
 
     if (whatsapp && orderId) {
       const order = await getRedis().getOrder(orderId);
-      const brandId = order?.brand_id || 'kanuka';
+      const brandId = order?.brand_id;
+
+      if (!brandId) {
+        logger.warn(
+          `Skipping notification: brand not found for order ${orderId}`
+        );
+        return res.send('OK');
+      }
+
       const brandConfig = loadBrandConfig(brandId) || {};
       const upper = brandId.toUpperCase();
       const phoneId = process.env[`META_PHONE_NUMBER_ID_${upper}`];


### PR DESCRIPTION
## Summary
- document single `RAZORPAY_WEBHOOK_SECRET` for webhook verification
- ensure payment webhook only notifies orders with a known brand context

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a223ba3cac8327b40052d998704444