### PR TITLE
Improve Razorpay signature validation

### DIFF
--- a/handlers/paymentWebhook.js
+++ b/handlers/paymentWebhook.js
@@ -14,11 +14,18 @@ function verifySignature(rawBody, signature, secret) {
   if (!secret || !rawBody || !signature) {
     return false;
   }
+
   const expected = crypto
     .createHmac('sha256', secret)
     .update(rawBody)
     .digest('hex');
-  return expected === signature;
+
+  const expectedBuf = Buffer.from(expected, 'utf8');
+  const signatureBuf = Buffer.from(signature, 'utf8');
+  if (expectedBuf.length !== signatureBuf.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(expectedBuf, signatureBuf);
 }
 
 async function handlePaymentWebhook(req, res) {

--- a/test/paymentWebhook.test.js
+++ b/test/paymentWebhook.test.js
@@ -23,3 +23,14 @@ test('verifySignature returns false when secret is missing', () => {
   const sig = crypto.createHmac('sha256', 'secret').update(payload).digest('hex');
   assert.strictEqual(verifySignature(payload, sig, secret), false);
 });
+
+test('verifySignature returns false for mismatched length', () => {
+  const payload = JSON.stringify({ ok: true });
+  const secret = 'secret';
+  const sig = crypto.createHmac('sha256', secret).update(payload).digest('hex');
+  // remove last character to create length mismatch
+  assert.strictEqual(
+    verifySignature(payload, sig.slice(0, -1), secret),
+    false
+  );
+});


### PR DESCRIPTION
## Summary
- use timing safe comparison for Razorpay webhook signatures
- add test for mismatched signature length

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2c414f2b48327b37eed33686b7844