### PR TITLE
Prevent Razorpay webhook 500 errors

### DIFF
--- a/handlers/webhook_handler.py
+++ b/handlers/webhook_handler.py
@@ -315,15 +315,18 @@ def payment_success():
 def payment_made():
     """Handle Razorpay payment webhook when payment is completed"""
     logger.info("Razorpay webhook received.")
-    data = request.get_json()
+    try:
+        data = request.get_json() or {}
 
-    if data.get("event") == "payment_link.paid":
-        payment_data = data.get("payload", {}).get("payment_link", {}).get("entity", {})
-        whatsapp_number = payment_data.get("customer", {}).get("contact")
-        order_id = payment_data.get("reference_id")
+        if data.get("event") == "payment_link.paid":
+            payment_data = data.get("payload", {}).get("payment_link", {}).get("entity", {})
+            whatsapp_number = payment_data.get("customer", {}).get("contact")
+            order_id = payment_data.get("reference_id")
 
-        if whatsapp_number and order_id:
-            send_text_message(whatsapp_number, "✅ Your payment is confirmed! Your order is being processed.")
-            confirm_order(whatsapp_number, order_id, "Pay Now")
+            if whatsapp_number and order_id:
+                send_text_message(whatsapp_number, "✅ Your payment is confirmed! Your order is being processed.")
+                confirm_order(whatsapp_number, order_id, "Pay Now")
+    except Exception as e:
+        logger.error(f"Error processing Razorpay webhook: {e}")
 
     return "OK", 200


### PR DESCRIPTION
## Summary
- ensure Razorpay webhook responds with 200 even when misconfigured or failing
- wrap Flask payment webhook in try/except to avoid crashing

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3e10565508327a3b8fd03ddaf3226